### PR TITLE
Missing payload fix

### DIFF
--- a/arm9/source/bootstrap.c
+++ b/arm9/source/bootstrap.c
@@ -36,7 +36,7 @@ int file_exists(char const* path) {
 
 void panic() {
 	const char* defnds = "/SRLSELECTOR/DEFAULT.NDS";
-	if(file_exists(defnds)
+	if(file_exists(defnds))
 		runNdsFile(defnds, 0, NULL);
 	printf("No payload found! :(\n");
 }

--- a/arm9/source/bootstrap.c
+++ b/arm9/source/bootstrap.c
@@ -27,26 +27,26 @@
 
 #include "nds_loader_arm9.h"
 
-int file_exists(char const* path){
+int file_exists(char const* path) {
 	struct stat st;
 	if(stat(path, &st) == 0)
 		return 1; // File exists
 	return 0;
 }
 
-void panic()
+void panic() {
 	const char* defnds = "/SRLSELECTOR/DEFAULT.NDS";
 	if(file_exists(defnds)
 		runNdsFile(defnds, 0, NULL);
 	printf("No payload found! :(\n");
 }
 
-int main( int argc, char **argv)
+int main( int argc, char **argv) {
 	consoleDemoInit();
 	scanKeys();
 	int keys = keysDown();
 
-	if(!fatInitDefault())
+	if(!fatInitDefault()) {
 		printf("FAT init failed!\n");
 		goto fail; // Bail out early
 	}

--- a/arm9/source/bootstrap.c
+++ b/arm9/source/bootstrap.c
@@ -22,53 +22,67 @@
 #include <fat.h>
 
 #include <stdio.h>
+#include <sys/stat.h>
+#include <string.h>
 
 #include "nds_loader_arm9.h"
 
-int main( int argc, char **argv) {
+int file_exists(char const* path){
+	struct stat st;
+	if(stat(path, &st) == 0)
+		return 1; // File exists
+	return 0;
+}
+
+void panic()
+	const char* defnds = "/SRLSELECTOR/DEFAULT.NDS";
+	if(file_exists(defnds)
+		runNdsFile(defnds, 0, NULL);
+	printf("No payload found! :(\n");
+}
+
+int main( int argc, char **argv)
 	consoleDemoInit();
 	scanKeys();
+	int keys = keysDown();
 
-	if(fatInitDefault()) {
-	if(keysDown() & KEY_A) {
-		runNdsFile("/SRLSELECTOR/A.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_B) {
-		runNdsFile("/SRLSELECTOR/B.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_SELECT) {
-		runNdsFile("/SRLSELECTOR/SELECT.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_START) {
-		runNdsFile("/SRLSELECTOR/START.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_RIGHT) {
-		runNdsFile("/SRLSELECTOR/RIGHT.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_LEFT) {
-		runNdsFile("/SRLSELECTOR/LEFT.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_UP) {
-		runNdsFile("/SRLSELECTOR/UP.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_DOWN) {
-		runNdsFile("/SRLSELECTOR/DOWN.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_R) {
-		runNdsFile("/SRLSELECTOR/R.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_L) {
-		runNdsFile("/SRLSELECTOR/L.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_X) {
-		runNdsFile("/SRLSELECTOR/X.NDS", 0, NULL);
-	} else if(
-		keysDown() & KEY_Y) {
-		runNdsFile("/SRLSELECTOR/Y.NDS", 0, NULL);
-	} else
-		runNdsFile("/SRLSELECTOR/DEFAULT.NDS", 0, NULL);
-	} else {
+	if(!fatInitDefault())
 		printf("FAT init failed!\n");
+		goto fail; // Bail out early
 	}
+	char buf[80] = {0};
+	strcat(buf, "/SRLSELECTOR/");
+	char *payload = NULL;
+	if(keys & KEY_A)
+		payload = "A.NDS";
+	else if(keys & KEY_B)
+		payload = "B.NDS";
+	else if(keys & KEY_SELECT)
+		payload = "SELECT.NDS";
+	else if(keys & KEY_START)
+		payload = "START.NDS";
+	else if(keys & KEY_RIGHT)
+		payload = "RIGHT.NDS";
+	else if(keys & KEY_LEFT)
+		payload = "LEFT.NDS";
+	else if(keys & KEY_UP)
+		payload = "UP.NDS";
+	else if(keys & KEY_DOWN)
+		payload = "DOWN.NDS";
+	else if(keys & KEY_R)
+		payload = "R.NDS";
+	else if(keys & KEY_L)
+		payload = "L.NDS";
+	else if(keys & KEY_X)
+		payload = "X.NDS";
+	else if(keys & KEY_Y)
+		payload = "Y.NDS";
+	else
+		panic();
+	strcat(buf, payload);
+	if(!file_exists(buf))
+		panic();
+	runNdsFile(buf, 0, NULL);
+fail:
 	while(1) swiWaitForVBlank();
 }


### PR DESCRIPTION
Addresses the issue pointed out in [this post](http://gbatemp.net/threads/release-srlselector-a-simple-boot-manager-for-the-nintendo-dsi.480996/page-2#post-7522366).

Note: I wasn't able to build this myself to test it, `make` is complaining about not having a rule to make 'load.bin.o'. You should build/test this on your own environment before doing anything.

Added file_exists() and panic() functions
* panic() checks for default.nds and fails loudly if none exists.

Refactored main() for easier reading/flow
* FAT init check jumps to a hang if it fails.
* keysDown() is called once and stored.
* Payload launch happens at end of main() so file_exists() is  
only called twice in the worst case.