### PR TITLE
Make error messages readable

### DIFF
--- a/BootStrap/arm9/source/bootstrap.c
+++ b/BootStrap/arm9/source/bootstrap.c
@@ -20,11 +20,9 @@
 
 #include <nds.h>
 #include <fat.h>
-
 #include <stdio.h>
 #include <sys/stat.h>
 #include <string.h>
-
 #include "nds_loader_arm9.h"
 
 int file_exists(char const* path) {
@@ -38,7 +36,7 @@ void panic() {
 	const char* defnds = "/SRLSELECTOR/DEFAULT.NDS";
 	if(file_exists(defnds))
 		runNdsFile(defnds, 0, NULL);
-	printf("No payload found! :(\n");
+	iprintf("No payload found! :(\n");
 }
 
 int main( int argc, char **argv) {
@@ -47,7 +45,7 @@ int main( int argc, char **argv) {
 	int keys = keysDown();
 
 	if(!fatInitDefault()) {
-		printf("FAT init failed!\n");
+		iprintf("FAT init failed!\n");
 		goto fail; // Bail out early
 	}
 	char buf[80] = {0};
@@ -77,12 +75,16 @@ int main( int argc, char **argv) {
 		payload = "X.NDS";
 	else if(keys & KEY_Y)
 		payload = "Y.NDS";
-	else
+	else {
+		// No keys held, execute the default or fail through
 		panic();
+		goto fail;
+	}
 	strcat(buf, payload);
-	if(!file_exists(buf))
-		panic();
-	runNdsFile(buf, 0, NULL);
+	if(file_exists(buf))
+		runNdsFile(buf, 0, NULL);
+	panic();
 fail:
+	powerOff(PM_BACKLIGHT_TOP);
 	while(1) swiWaitForVBlank();
 }

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ SRLSelector is a simple boot manager based on the bootstrap from nds-hbmenu by C
 ## Instructions
 Put the BOOT.NDS from the release on the root of your SD and create a folder called /SRLSELECTOR, then put your DSi's homebrew inside the 
 folder and rename them to the botton you want to assing (Example: B.NDS, DOWN.NDS, START.NDS, etc). Name DEFAULT.NDS the homebrew you want to
-autoboot by default, If you want to know what bottons are supported take a look [here.](BootStrap/arm9/source/bootstrap.c#L56-L79) Then simply boot your
+autoboot by default, If you want to know what bottons are supported take a look [here.](BootStrap/arm9/source/bootstrap.c#L54-L77) Then simply boot your
 favorite dsiwarehax, hold the botton of the homebrew you want (or don't hold anything if you want to run the default) and enjoy.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ SRLSelector is a simple boot manager based on the bootstrap from nds-hbmenu by C
 ## Instructions
 Put the BOOT.NDS from the release on the root of your SD and create a folder called /SRLSELECTOR, then put your DSi's homebrew inside the 
 folder and rename them to the botton you want to assing (Example: B.NDS, DOWN.NDS, START.NDS, etc). Name DEFAULT.NDS the homebrew you want to
-autoboot by default, If you want to know what bottons are supported take a look [here.](arm9/source/bootstrap.c#L34-L67) Then simply boot your
+autoboot by default, If you want to know what bottons are supported take a look [here.](BootStrap/arm9/source/bootstrap.c#L56-L79) Then simply boot your
 favorite dsiwarehax, hold the botton of the homebrew you want (or don't hold anything if you want to run the default) and enjoy.


### PR DESCRIPTION
Changed printf calls to iprintf so they don't clear on vblank.
Loading the program with no keys held and no default.nds will now jump
directly to the fail state.
Also turns off the top screen if the payload fails.